### PR TITLE
remarkable version upgrade to 1.7.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/acdlite/react-remarkable.git"
   },
   "dependencies": {
-    "remarkable": "^1.4.1"
+    "remarkable": "^1.7.1"
   },
   "devDependencies": {
     "babel": "^5.1.13"


### PR DESCRIPTION
Updated remarkable version to utilize the linkTarget option, which allows adding target="_blank" to links in order to open them in separate tabs/windows.